### PR TITLE
Fix passing extra parameter to start_dashboard

### DIFF
--- a/zstack-dashboard
+++ b/zstack-dashboard
@@ -126,12 +126,12 @@ fi
 if [ "$@" = "status" ]; then
     check_status
 elif [ "$@" = "start" ]; then
-    start_dashboard
+    start_dashboard $*
 elif [ "$@" = "stop" ]; then
     stop_dashboard
 elif [ "$@" = "restart" ]; then
     stop_dashboard
-    start_dashboard
+    start_dashboard $*
 else
     echo "Not support service: $@. Please use [start|stop|restart|status]"
     exit 1


### PR DESCRIPTION
/etc/init.d/zstack-dashboard start will fail when install latest built all-in-one package on ubuntu 14.04. Since there is no argument to shift when calling start_dashboard(), and it will fail out with sh